### PR TITLE
L2 config sample: Fixing indentation in the cancel request rule

### DIFF
--- a/api/l2-config/oas-3.1/ondemandride/example-rules/requests/cancel/cancellation_rules.yaml
+++ b/api/l2-config/oas-3.1/ondemandride/example-rules/requests/cancel/cancellation_rules.yaml
@@ -12,9 +12,9 @@ properties:
               - CONFIRM_CANCEL
         required:
           - code
-        cancellation_reason_id:
-          type: string
-          pattern: '^[0-9]+$'
+      cancellation_reason_id:
+        type: string
+        pattern: '^[0-9]+$'
     required:
       - order_id
       - descriptor

--- a/api/l2-config/oas-3.1/ondemandride/mobility_ondemandride_1.1.0_openapi_3.1.yaml
+++ b/api/l2-config/oas-3.1/ondemandride/mobility_ondemandride_1.1.0_openapi_3.1.yaml
@@ -2325,9 +2325,9 @@ paths:
                                     - CONFIRM_CANCEL
                               required:
                                 - code
-                              cancellation_reason_id:
-                                type: string
-                                pattern: '^[0-9]+$'
+                            cancellation_reason_id:
+                              type: string
+                              pattern: '^[0-9]+$'
                           required:
                             - order_id
                             - descriptor


### PR DESCRIPTION
### Description

This PR fixes a wrong indentation in ``` api/l2-config/oas-3.1/ondemandride/example-rules/requests/cancel/cancellation_rules.yaml ```
